### PR TITLE
Fix for CSS includes if the user configures bundle with include_* to false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FMSummernoteBundle
 ==============
 
-FMSummernoteBundle adds summenote bundle 
+FMSummernoteBundle adds summernote bundle 
 
 ## Installation
 
@@ -67,7 +67,7 @@ fm_summernote:
 Twig template example
 
 ```twig
-    {{ summenote_init() }}    
+    {{ summernote_init() }}    
     <textarea class="summernote"></textarea>  
 ```    
 

--- a/Resources/views/init.html.twig
+++ b/Resources/views/init.html.twig
@@ -1,6 +1,3 @@
-{% block stylesheets %}
-{% endblock %}
-
 {% if sn.include_jquery %}
     <script src="{{ asset(base_path ~ sn.jquery_path) }}"></script>
 {% endif %}

--- a/Resources/views/init.html.twig
+++ b/Resources/views/init.html.twig
@@ -1,15 +1,17 @@
 {% block stylesheets %}
-    <link href="{{ asset(base_path ~ sn.bootstrap_css_path) }}" rel="stylesheet" type="text/css">
-    <link href="{{ asset(base_path ~ sn.fontawesome_path) }}" rel="stylesheet" type="text/css">
-    <link href="{{ asset(base_path ~ sn.summernote_css_path) }}" rel="stylesheet" type="text/css">
 {% endblock %}
 
 {% if sn.include_jquery %}
     <script src="{{ asset(base_path ~ sn.jquery_path) }}"></script>
 {% endif %}
 {% if sn.include_bootstrap %}
+    <link href="{{ asset(base_path ~ sn.bootstrap_css_path) }}" rel="stylesheet" type="text/css">
     <script src="{{ asset(base_path ~ sn.bootstrap_js_path) }}"></script>
 {% endif %}
+{% if sn.include_fontawesome %}
+    <link href="{{ asset(base_path ~ sn.fontawesome_path) }}" rel="stylesheet" type="text/css">
+{% endif %}
+<link href="{{ asset(base_path ~ sn.summernote_css_path) }}" rel="stylesheet" type="text/css">
 <script type="text/javascript" src="{{ asset(base_path ~ sn.summernote_js_path) }}"></script>
 {% if sn.language is not null %}
     <script type="text/javascript" src="{{ asset(base_path ~ 'lang/summernote-'~lang~'.js') }}"></script>

--- a/Twig/Extension/FMSummernoteExtension.php
+++ b/Twig/Extension/FMSummernoteExtension.php
@@ -33,7 +33,7 @@ class FMSummernoteExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('summenote_init', [$this, 'summernoteInit'], ['is_safe' => ['html']]),
+            new \Twig_SimpleFunction('summernote_init', [$this, 'summernoteInit'], ['is_safe' => ['html']]),
         ];
     }
 


### PR DESCRIPTION
Changes:
* moved the **bootstrap css** asset inside the **include_bootstrap if statement** and created a **new if statement for the fontawesome asset**.
* renamed the twig function from **summenote_init** to **summernote_init**.