### PR TITLE
Enable language choice in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ fm_summernote:
         elfinder: [elfinder]
     width: 600
     height: 400
+    language: ‘’ # define language (with language culture code like de-DE, fr-FR, etc.) by default, it is in english
     include_jquery: true #include js libraries, if your template already have them, set to false
     include_bootstrap: true
     include_fontawesome: true

--- a/Resources/views/init.html.twig
+++ b/Resources/views/init.html.twig
@@ -11,7 +11,7 @@
 <link href="{{ asset(base_path ~ sn.summernote_css_path) }}" rel="stylesheet" type="text/css">
 <script type="text/javascript" src="{{ asset(base_path ~ sn.summernote_js_path) }}"></script>
 {% if sn.language is not null %}
-    <script type="text/javascript" src="{{ asset(base_path ~ 'lang/summernote-'~lang~'.js') }}"></script>
+    <script type="text/javascript" src="{{ asset(base_path ~ 'lang/summernote-'~sn.language~'.js') }}"></script>
 {% endif %}
 {% if sn.plugins is not null %}
     {% for plugin in sn.plugins %}


### PR DESCRIPTION
Sorry for my (very bad) english
Summernote allows the choice of multiple languages... it seems there was a mistake in init.html.twig ("lang" which does not exist) so I fixed it