### PR TITLE
Bracket fix

### DIFF
--- a/Twig/Extension/FMSummernoteExtension.php
+++ b/Twig/Extension/FMSummernoteExtension.php
@@ -46,7 +46,7 @@ class FMSummernoteExtension extends \Twig_Extension
         $options = [];
 
         $options['fontname'] = count($this->parameters['fontname']) > 0 ? $this->prepareArrayParameter('fontname') : $this->getDefaultFontname();
-        $options['fontnocheck'] = count($this->parameters['fontnocheck'] > 0) ? $this->prepareArrayParameter('fontnocheck') : null;
+        $options['fontnocheck'] = count($this->parameters['fontnocheck']) > 0 ? $this->prepareArrayParameter('fontnocheck') : null;
         $options['language'] = isset($this->parameters['language']) ? $this->parameters['language'] : null;
         $options['plugins'] = isset($this->parameters['plugins']) ? $this->parameters['plugins'] : null;
         $options['selector'] = $this->parameters['selector'];


### PR DESCRIPTION
I found a bracket error, in my case this throws an ErrorException in the summernote_init() function in Twig template.

The ErrorException: **Warning: count(): Parameter must be an array or an object that implements Countable**