### PR TITLE
basePath configuration name changed to base_path

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -32,7 +32,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('jquery_path')->defaultValue('vendor/jquery.min.js')->end()
                 ->scalarNode('summernote_css_path')->defaultValue('summernote.css')->end()
                 ->scalarNode('summernote_js_path')->defaultValue('summernote.min.js')->end()
-                ->scalarNode('basePath')->end()
+                ->scalarNode('base_path')->end()
                 ->scalarNode('init_template')->defaultValue('FMSummernoteBundle::init.html.twig')->end()
                 ->scalarNode('selector')->defaultValue('.summernote')->end()
                 ->scalarNode('language')->end()


### PR DESCRIPTION
The Configuration.php file basePath parameter doesn't match in the init.html.twig base_path parameter and can't redefine in the YAML config.